### PR TITLE
Privileges check message missing

### DIFF
--- a/Make.rules
+++ b/Make.rules
@@ -78,7 +78,7 @@ DESTDIR =
 
 
 #  layout stuff
-SKIPDIRS = tmp%
+SKIPDIRS = tmp% binaries% dockerfiles%
 INCLUDEDIRS = include%
 LIBDIRS = lib%
 MODDIRS = mod%

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ include ./Make.rules
 
 targets = $(EXEDIRS) $(LIBDIRS) $(MODDIRS)
 
-
 # be happy, easy, perfomancy...
 .PHONY: $(subdirs) dummy all force
 .PHONY: depend indent clean distclean libclean release store libs mods
@@ -77,6 +76,7 @@ endif
 $(targets): mkfile = $(if $(wildcard $@/Makefile),,-f $(srcdir)/default.rules)
 
 $(targets): force
+	@echo Doing $@
 	@$(MAKE) $(mkfile) -C $@ $(what) TARGET=$@
 
 force:

--- a/traceroute/mod-icmp.c
+++ b/traceroute/mod-icmp.c
@@ -110,7 +110,7 @@ static int icmp_init(const sockaddr_any* dest, unsigned int port_seq, size_t *pa
         raw_icmp_sk = socket(dest_addr.sa.sa_family, SOCK_RAW, (dest_addr.sa.sa_family == AF_INET) ? IPPROTO_ICMP : IPPROTO_ICMPV6);
         
         if(raw_icmp_sk < 0)
-            error("raw icmp socket");
+            error_or_perm("raw icmp socket");
         
         add_poll(raw_icmp_sk, POLLIN | POLLERR);
     }

--- a/traceroute/mod-tcp.c
+++ b/traceroute/mod-tcp.c
@@ -345,7 +345,7 @@ static int tcp_init(const sockaddr_any* dest, unsigned int port_seq, size_t* pac
         raw_icmp_sk = socket(dest_addr.sa.sa_family, SOCK_RAW, (dest_addr.sa.sa_family == AF_INET) ? IPPROTO_ICMP : IPPROTO_ICMPV6);
         
         if(raw_icmp_sk < 0)
-            error("raw icmp socket");
+            error_or_perm("raw icmp socket");
         
         add_poll(raw_icmp_sk, POLLIN | POLLERR);
     }
@@ -367,7 +367,7 @@ static void tcp_send_probe(probe* pb, int ttl)
 
     sk = socket(af, SOCK_STREAM, 0);
     if(sk < 0)
-        error ("socket");
+        error("socket");
 
     if(reuse && setsockopt (sk, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
         error ("setsockopt SO_REUSEADDR");

--- a/traceroute/mod-tcpinsession.c
+++ b/traceroute/mod-tcpinsession.c
@@ -495,7 +495,7 @@ static int tcpinsession_init(const sockaddr_any* dest, unsigned int port_seq, si
         raw_icmp_sk = socket(dest_addr.sa.sa_family, SOCK_RAW, (dest_addr.sa.sa_family == AF_INET) ? IPPROTO_ICMP : IPPROTO_ICMPV6);
         
         if(raw_icmp_sk < 0)
-            error("raw icmp socket");
+            error_or_perm("raw icmp socket");
         
         lenp = (uint16_t*)(buf + delta_len_p); // Allow the length in the pseudo IP header to be changed when we send probes 
         

--- a/traceroute/mod-udp.c
+++ b/traceroute/mod-udp.c
@@ -62,7 +62,7 @@ static int udp_default_init(const sockaddr_any* dest, unsigned int port_seq, siz
         raw_icmp_sk = socket(dest_addr.sa.sa_family, SOCK_RAW, (dest_addr.sa.sa_family == AF_INET) ? IPPROTO_ICMP : IPPROTO_ICMPV6);
         
         if(raw_icmp_sk < 0)
-            error("raw icmp socket");
+            error_or_perm("raw icmp socket");
         
         add_poll(raw_icmp_sk, POLLIN | POLLERR);
     }


### PR DESCRIPTION
Print proper message when the raw icmp socket cannot be used.

This also includes a fix tro Make.rules to exclude additional dirs from the automatic scan